### PR TITLE
Transitive dependencies

### DIFF
--- a/src/fs/node-package-fs.spec.ts
+++ b/src/fs/node-package-fs.spec.ts
@@ -13,18 +13,21 @@ import { resolveRootPackage } from './resolve-root-package.js';
 describe('NodePackageFS', () => {
   let fs: NodePackageFS;
 
-  beforeEach(() => {
-    fs = new NodePackageFS();
+  beforeEach(async () => {
+    fs = await NodePackageFS.create();
   });
 
   describe('create', () => {
-    it('create fs by path', () => {
-      expect(new NodePackageFS('.').root).toBe(pathToFileURL('.').href);
-    });
-    it('creates fs by file URL', () => {
-      const root = pathToFileURL('.').href;
+    it('create fs by path', async () => {
+      const fs = await NodePackageFS.create('.');
 
-      expect(new NodePackageFS(root).root).toBe(root);
+      expect(fs.root).toBe(pathToFileURL('.').href);
+    });
+    it('creates fs by file URL', async () => {
+      const root = pathToFileURL('.').href;
+      const fs = await NodePackageFS.create(root);
+
+      expect(fs.root).toBe(root);
     });
   });
 

--- a/src/fs/node-package-fs.ts
+++ b/src/fs/node-package-fs.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath, pathToFileURL } from 'node:url';
 import { PackageInfo } from '../package/package-info.js';
 import { PackageJson, isValidPackageJson } from '../package/package.json.js';
 import { Import } from '../resolution/import.js';
@@ -16,21 +15,18 @@ export class NodePackageFS extends PackageFS {
    * @param root - URL or path of the root directory. Defaults to current working directory.
    */
   static async create(root?: string): Promise<NodePackageFS> {
-    const { default: process } = await import('node:process');
-
-    if (!root) {
-      root = pathToFileURL(process.cwd()).href;
-    } else if (!root.startsWith('file://')) {
-      root = pathToFileURL(root).href;
-    }
-
-    return await new NodePackageFS(root).init();
+    return await new NodePackageFS().init(root);
   }
 
-  readonly #root: string;
-  #path!: typeof import('node:path');
+  #root!: string;
+
   #fs!: typeof import('node:fs/promises');
+  #fsRoot!: URL;
+  #path!: typeof import('node:path');
   #nodeModule!: typeof import('node:module');
+  #nodeBuiltins!: Set<string>;
+  #url!: typeof import('node:url');
+  #win32!: typeof import('node:path/win32');
 
   /**
    * Constructs file system with the given root.
@@ -38,13 +34,9 @@ export class NodePackageFS extends PackageFS {
    * The file system has to be {@link init initialized} after construction.
    *
    * Use static {@link NodePackageFS.create} method instead to create file system instances.
-   *
-   * @param root - URL of the root directory.
    */
-  protected constructor(root: string) {
+  protected constructor() {
     super();
-
-    this.#root = root;
   }
 
   /**
@@ -52,24 +44,197 @@ export class NodePackageFS extends PackageFS {
    *
    * This method has to be called prior to start using the FS.
    *
+   * @param root - URL or path of the root directory. Defaults to current working directory.
+   *
    * @returns Promise resolved to `this` instance.
    */
-  async init(): Promise<this> {
-    const [{ default: path }, { default: fs }, { default: nodeModule }] = await Promise.all([
-      import('node:path'),
+  async init(root?: string): Promise<this> {
+    const [
+      { default: fs },
+      { default: nodeModule },
+      { default: path },
+      { default: win32 },
+      { default: process },
+      { default: url },
+    ] = await Promise.all([
       import('node:fs/promises'),
       import('node:module'),
+      import('node:path'),
+      import('node:path/win32'),
+      import('node:process'),
+      import('node:url'),
     ]);
+
+    if (!root) {
+      this.#root = url.pathToFileURL(process.cwd()).href;
+    } else if (root.startsWith('file://')) {
+      this.#root = root;
+    } else {
+      this.#root = url.pathToFileURL(root).href;
+    }
 
     this.#path = path;
     this.#fs = fs;
+    this.#fsRoot = url.pathToFileURL(path.parse(process.cwd()).root);
     this.#nodeModule = nodeModule;
+    this.#nodeBuiltins = new Set(nodeModule.builtinModules);
+    this.#url = url;
+    this.#win32 = win32;
 
     return this;
   }
 
   override get root(): string {
     return this.#root;
+  }
+
+  /**
+   * File system root URL.
+   */
+  get fsRoot(): string {
+    return this.#fsRoot.href;
+  }
+
+  /**
+   * Recognizes Node.js import specifier and parses it accordingly.
+   *
+   * In addition to imports recognized by {@link recognizeImport}, this method recognizes Node.js built-ins and
+   * Windows/Unix paths.
+   *
+   * @param spec - Import specifier to recognize. May be recognized already.
+   *
+   * @returns Recognized import specifier.
+   */
+  override recognizeImport(spec: string): Import {
+    return this.#recognizeNodeImport(spec) ?? super.recognizeImport(spec);
+  }
+
+  #recognizeNodeImport(spec: string): Import | void {
+    switch (spec[0]) {
+      case '/':
+        return this.#recognizeAbsoluteUnixImport(spec);
+      case '.':
+        return this.#recognizeRelativeImport(spec);
+      case '\\':
+        return this.#recognizeUNCWindowsImport(spec);
+      default:
+        return this.#recognizeNodeBuiltin(spec) ?? this.#recognizeAbsoluteWindowsImport(spec);
+    }
+  }
+
+  #recognizeNodeBuiltin(spec: string): Import.Implied | undefined {
+    if (this.#nodeBuiltins.has(spec.startsWith('node:') ? spec.slice(5) : spec)) {
+      return {
+        kind: 'implied',
+        spec,
+        from: 'node',
+      };
+    }
+
+    return;
+  }
+
+  #recognizeAbsoluteUnixImport(spec: string): Import.Absolute {
+    const url = new URL(spec, this.#fsRoot);
+    const path: `/${string}` = `/${
+      url.pathname.slice(this.#fsRoot.pathname.length) + url.search + url.hash
+    }`;
+
+    return {
+      kind: 'path',
+      spec,
+      isRelative: false,
+      path,
+      uri: path,
+    };
+  }
+
+  #recognizeRelativeImport(spec: string): Import.Relative | void {
+    if (spec === '.' || spec === '..') {
+      return {
+        kind: 'path',
+        spec,
+        isRelative: true,
+        path: spec,
+        uri: spec,
+      };
+    }
+
+    if (spec.startsWith('./') || spec.startsWith('../')) {
+      // Unix path.
+      const path = this.#relativeURIPath(spec);
+
+      return {
+        kind: 'path',
+        spec,
+        isRelative: true,
+        path,
+        uri: path,
+      };
+    }
+
+    if (spec.startsWith('.\\') || spec.startsWith('..\\')) {
+      // Windows path.
+      const path = this.#windowsURIPath(spec) as `./${string}` | `../${string}`;
+
+      return {
+        kind: 'path',
+        spec,
+        isRelative: true,
+        path,
+        uri: path,
+      };
+    }
+  }
+
+  #recognizeUNCWindowsImport(spec: string): Import.Absolute | undefined {
+    if (WINDOWS_DRIVE_PATH_PATTERN.test(spec)) {
+      return this.#createAbsoluteWindowsImport(spec);
+    }
+
+    const path = this.#windowsURIPath(this.#win32.toNamespacedPath(spec)) as `/${string}`;
+
+    return {
+      kind: 'path',
+      spec,
+      isRelative: false,
+      path,
+      uri: `file://${path}`,
+    };
+  }
+
+  #recognizeAbsoluteWindowsImport(spec: string): Import.Absolute | void {
+    if (this.#win32.isAbsolute(spec)) {
+      return this.#createAbsoluteWindowsImport(spec);
+    }
+  }
+
+  #createAbsoluteWindowsImport(spec: string): Import.Absolute {
+    const path = this.#windowsURIPath(spec.startsWith('\\') ? spec : '\\' + spec) as `/${string}`;
+
+    return {
+      kind: 'path',
+      spec,
+      isRelative: false,
+      path,
+      uri: `file://${path}`,
+    };
+  }
+
+  #relativeURIPath(path: string): `./${string}` | `../${string}` {
+    const pathStart = path.indexOf('/');
+    const url = new URL(path.slice(pathStart), this.#fsRoot);
+
+    return (path.slice(0, pathStart + 1)
+      + url.pathname.slice(this.#fsRoot.pathname.length)
+      + url.search
+      + url.hash) as `./${string}` | `../${string}`;
+  }
+
+  #windowsURIPath(path: string): string {
+    const unixPath = path.replaceAll('\\', '/');
+
+    return encodeURI(`${unixPath}`).replace(/[?#]/g, encodeURIComponent) as `/${string}`;
   }
 
   override recognizePackageURI(importSpec: Import.URI): string | undefined {
@@ -92,11 +257,11 @@ export class NodePackageFS extends PackageFS {
       return; // Ignore unresolved package.
     }
 
-    return pathToFileURL(modulePath).href;
+    return this.#url.pathToFileURL(modulePath).href;
   }
 
   override async loadPackage(uri: string): Promise<PackageInfo | undefined> {
-    const dir = fileURLToPath(uri);
+    const dir = this.#url.fileURLToPath(uri);
     const filePath = this.#path.join(dir, 'package.json');
 
     try {
@@ -115,14 +280,16 @@ export class NodePackageFS extends PackageFS {
   }
 
   override parentDir(uri: string): string | undefined {
-    const dir = fileURLToPath(uri);
+    const dir = this.#url.fileURLToPath(uri);
     const parentDir = this.#path.dirname(dir);
 
     if (parentDir === dir) {
       return;
     }
 
-    return pathToFileURL(parentDir).href;
+    return this.#url.pathToFileURL(parentDir).href;
   }
 
 }
+
+const WINDOWS_DRIVE_PATH_PATTERN = /^\\?[a-z0-9]+:\\/i;

--- a/src/fs/package-fs.ts
+++ b/src/fs/package-fs.ts
@@ -2,6 +2,7 @@ import { PackageInfo } from '../package/package-info.js';
 import { ImportResolution } from '../resolution/import-resolution.js';
 import { Import } from '../resolution/import.js';
 import { PackageResolution } from '../resolution/package-resolution.js';
+import { recognizeImport } from '../resolution/recognize-import.js';
 import { PackageDir } from './package-dir.js';
 
 /**
@@ -17,6 +18,21 @@ export abstract class PackageFS {
    * URI of the root package.
    */
   abstract get root(): string;
+
+  /**
+   * Recognizes import specifier and parses it accordingly.
+   *
+   * In contrast to {@link recognizeImport}, this method may recognize imports specific to file system.
+   *
+   * By default, calls {@link recognizeImport} function.
+   *
+   * @param spec - Import specifier to recognize. May be recognized already.
+   *
+   * @returns Recognized import specifier.
+   */
+  recognizeImport(spec: string): Import {
+    return recognizeImport(spec);
+  }
 
   /**
    * Extracts package URI from compatible URI import specifier.

--- a/src/fs/resolve-root-package.spec.ts
+++ b/src/fs/resolve-root-package.spec.ts
@@ -13,7 +13,8 @@ describe('resolveRootPackage', () => {
   });
   it('obtains current package by default', async () => {
     const root = await resolveRootPackage();
+    const packageInfo = await PackageInfo.load();
 
-    expect(root.packageInfo.name).toBe(PackageInfo.loadSync().name);
+    expect(root.packageInfo.packageJson).toEqual(packageInfo.packageJson);
   });
 });

--- a/src/fs/resolve-root-package.ts
+++ b/src/fs/resolve-root-package.ts
@@ -16,8 +16,8 @@ import { PackageFS } from './package-fs.js';
  */
 
 export async function resolveRootPackage(dirOrFS?: string | PackageFS): Promise<PackageResolution> {
-  const fs = dirOrFS == null || typeof dirOrFS === 'string' ? new NodePackageFS() : dirOrFS;
-
+  const fs =
+    dirOrFS == null || typeof dirOrFS === 'string' ? await NodePackageFS.create(dirOrFS) : dirOrFS;
   const rootPackageInfo = await fs.loadPackage(fs.root);
 
   if (!rootPackageInfo) {

--- a/src/impl/fs-root.ts
+++ b/src/impl/fs-root.ts
@@ -1,5 +1,0 @@
-import { parse } from 'node:path';
-import process from 'node:process';
-import { pathToFileURL } from 'node:url';
-
-export const FS_ROOT = /*#__PURE__*/ pathToFileURL(/*#__PURE__*/ parse(process.cwd()).root);

--- a/src/impl/generic.resolution.ts
+++ b/src/impl/generic.resolution.ts
@@ -1,6 +1,5 @@
 import { ImportResolution } from '../resolution/import-resolution.js';
 import { Import } from '../resolution/import.js';
-import { recognizeImport } from '../resolution/recognize-import.js';
 import { ImportResolver } from './import-resolver.js';
 import { Import$Resolution } from './import.resolution.js';
 
@@ -14,7 +13,7 @@ export class Generic$Resolution extends Import$Resolution<Import> {
   }
 
   override async resolveImport(spec: Import | string): Promise<ImportResolution> {
-    return await this.#resolver.resolve(recognizeImport(spec));
+    return await this.#resolver.resolve(this.#resolver.recognizeImport(spec));
   }
 
 }

--- a/src/impl/import-resolver.ts
+++ b/src/impl/import-resolver.ts
@@ -46,6 +46,14 @@ export class ImportResolver {
     return this.#fs;
   }
 
+  recognizeImport<TImport extends Import>(spec: TImport): TImport;
+
+  recognizeImport(spec: Import | string): Import;
+
+  recognizeImport(spec: Import | string): Import {
+    return typeof spec === 'string' ? this.fs.recognizeImport(spec) : spec;
+  }
+
   async resolve(spec: Import): Promise<ImportResolution> {
     if (spec.kind === 'uri') {
       return await this.resolveURI(spec);

--- a/src/impl/import-resolver.ts
+++ b/src/impl/import-resolver.ts
@@ -160,7 +160,8 @@ export class ImportResolver {
   ): Promise<ImportResolution | undefined> {
     const {
       packageInfo: {
-        packageJson: { dependencies, devDependencies, peerDependencies },
+        peerDependencies,
+        packageJson: { dependencies, devDependencies },
       },
     } = host;
     const dep =

--- a/src/impl/import.resolution.ts
+++ b/src/impl/import.resolution.ts
@@ -1,5 +1,5 @@
 import { AmbientDependency, ImportDependency } from '../resolution/import-dependency.js';
-import { ImportResolution } from '../resolution/import-resolution.js';
+import { ImportDependencyRequest, ImportResolution } from '../resolution/import-resolution.js';
 import { Import } from '../resolution/import.js';
 import { PackageResolution } from '../resolution/package-resolution.js';
 import { SubPackageResolution } from '../resolution/sub-package-resolution.js';
@@ -40,7 +40,10 @@ export abstract class Import$Resolution<TImport extends Import>
 
   abstract resolveImport(spec: Import | string): Promise<ImportResolution>;
 
-  resolveDependency(on: ImportResolution): ImportDependency | null {
+  resolveDependency(
+    on: ImportResolution,
+    request?: ImportDependencyRequest,
+  ): ImportDependency | null {
     if (on.uri === this.uri) {
       // Import itself.
       return { kind: 'self', on };
@@ -56,7 +59,7 @@ export abstract class Import$Resolution<TImport extends Import>
 
       if (host.uri !== this.uri) {
         // Resolve host package dependency instead.
-        return host.resolveDependency(on);
+        return host.resolveDependency(on, request);
       }
     }
 

--- a/src/impl/import.resolution.ts
+++ b/src/impl/import.resolution.ts
@@ -1,3 +1,4 @@
+import { PackageFS } from '../fs/package-fs.js';
 import { AmbientDependency, ImportDependency } from '../resolution/import-dependency.js';
 import { ImportDependencyRequest, ImportResolution } from '../resolution/import-resolution.js';
 import { Import } from '../resolution/import.js';
@@ -16,6 +17,10 @@ export abstract class Import$Resolution<TImport extends Import>
     this.#resolver = resolver;
     this.#uri = uri;
     this.#importSpec = importSpec;
+  }
+
+  get fs(): PackageFS {
+    return this.#resolver.fs;
   }
 
   get root(): ImportResolution {

--- a/src/impl/package.resolution.ts
+++ b/src/impl/package.resolution.ts
@@ -1,9 +1,10 @@
 import { type PackageInfo } from '../package/package-info.js';
 import { type PackageJson } from '../package/package.json.js';
 import { ImportDependency, SubPackageDependency } from '../resolution/import-dependency.js';
-import { ImportResolution } from '../resolution/import-resolution.js';
+import { ImportDependencyRequest, ImportResolution } from '../resolution/import-resolution.js';
 import { Import } from '../resolution/import.js';
 import { PackageResolution } from '../resolution/package-resolution.js';
+import { SubPackageResolution } from '../resolution/sub-package-resolution.js';
 import { dirURI } from './dir-uri.js';
 import { ImportResolver } from './import-resolver.js';
 import { parseRange } from './parse-range.js';
@@ -15,7 +16,7 @@ export class Package$Resolution
 
   readonly #resolutionBaseURI: string;
   readonly #packageInfo: PackageInfo;
-  readonly #dependencies = new Map<string, PackageDep | false>();
+  readonly #dependencies = new Map<string, ImportDependency | false>();
 
   constructor(
     resolver: ImportResolver,
@@ -45,25 +46,35 @@ export class Package$Resolution
     return this.#packageInfo;
   }
 
-  override resolveDependency(another: ImportResolution): ImportDependency | null {
-    const importDependency = super.resolveDependency(another);
+  override resolveDependency(
+    on: ImportResolution,
+    request?: ImportDependencyRequest,
+  ): ImportDependency | null {
+    const importDependency = super.resolveDependency(on, request);
 
     if (importDependency) {
       return importDependency;
     }
 
     // Find dependency on host package.
-    const on = another.asSubPackage();
+    const subPackage = on.asSubPackage();
 
-    if (!on) {
+    if (!subPackage) {
       return null;
     }
 
+    return this.#resolveSubPackageDep(subPackage, request);
+  }
+
+  #resolveSubPackageDep(
+    on: SubPackageResolution,
+    request?: ImportDependencyRequest,
+  ): ImportDependency | null {
     const { host } = on;
     const knownDep = this.#dependencies.get(host.uri);
 
     if (knownDep != null) {
-      return knownDep ? { kind: knownDep.kind, on } : null;
+      return knownDep || null;
     }
 
     const {
@@ -74,30 +85,71 @@ export class Package$Resolution
     const dep =
       this.#findDep(host, dependencies, 'runtime')
       || this.#findDep(host, peerDependencies, 'peer')
-      || this.#findDep(host, devDependencies, 'dev');
+      || this.#findDep(host, devDependencies, 'dev')
+      || this.#findTransientDep(host, request?.via);
 
-    this.#dependencies.set(host.uri, dep ? dep : false);
+    this.#dependencies.set(host.uri, dep ?? false);
 
-    return dep && { kind: dep.kind, on };
+    return dep;
   }
 
   #findDep(
-    pkg: PackageResolution,
+    on: PackageResolution,
     dependencies: PackageJson.Dependencies | undefined,
     kind: SubPackageDependency['kind'],
-  ): PackageDep | null {
+  ): ImportDependency | null {
     if (!dependencies) {
       return null;
     }
 
-    const { name, version } = pkg.packageInfo;
+    const { name, version } = on.packageInfo;
     const range = parseRange(dependencies[name]);
 
     if (!range?.test(version)) {
       return null;
     }
 
-    return { kind, on: pkg };
+    return { kind, on };
+  }
+
+  #findTransientDep(
+    on: PackageResolution,
+    via: ImportResolution | undefined,
+  ): ImportDependency | null {
+    if (!via) {
+      return null;
+    }
+
+    const interimDep = this.resolveDependency(via);
+
+    if (!interimDep) {
+      return null;
+    }
+
+    const { kind, on: interim } = interimDep;
+    const dep = interim.resolveDependency(on);
+
+    if (dep) {
+      switch (kind) {
+        case 'dev':
+        case 'runtime':
+        case 'peer':
+          return { kind, on };
+        // istanbul ignore next
+        case 'implied':
+        // istanbul ignore next
+        // eslint-disable-next-line no-fallthrough
+        case 'synthetic':
+          // istanbul ignore next
+          return interimDep;
+        // istanbul ignore next
+        case 'self':
+          // istanbul ignore next
+          return dep;
+      }
+    }
+
+    return dep;
   }
 
   override asPackage(): this {
@@ -130,9 +182,4 @@ function packageImportSpec(
 
 export interface Package$Resolution extends PackageResolution {
   asImpliedResolution(): undefined;
-}
-
-interface PackageDep {
-  readonly kind: SubPackageDependency['kind'];
-  readonly on: PackageResolution;
 }

--- a/src/impl/package.resolution.ts
+++ b/src/impl/package.resolution.ts
@@ -4,7 +4,6 @@ import { ImportDependency, SubPackageDependency } from '../resolution/import-dep
 import { ImportResolution } from '../resolution/import-resolution.js';
 import { Import } from '../resolution/import.js';
 import { PackageResolution } from '../resolution/package-resolution.js';
-import { recognizeImport } from '../resolution/recognize-import.js';
 import { dirURI } from './dir-uri.js';
 import { ImportResolver } from './import-resolver.js';
 import { parseRange } from './parse-range.js';
@@ -23,7 +22,7 @@ export class Package$Resolution
     resolver: ImportResolver,
     uri: string,
     packageInfo: PackageInfo,
-    importSpec: Import.Package = packageImportSpec(packageInfo),
+    importSpec: Import.Package = packageImportSpec(resolver, packageInfo),
   ) {
     super(resolver, uri, importSpec);
 
@@ -134,8 +133,11 @@ export class Package$Resolution
 
 }
 
-function packageImportSpec({ name, scope, localName }: PackageInfo): Import.Package {
-  const spec = recognizeImport(name);
+function packageImportSpec(
+  resolver: ImportResolver,
+  { name, scope, localName }: PackageInfo,
+): Import.Package {
+  const spec = resolver.recognizeImport(name);
 
   if (spec.kind === 'package') {
     return spec;

--- a/src/impl/package.resolution.ts
+++ b/src/impl/package.resolution.ts
@@ -88,7 +88,9 @@ export class Package$Resolution
       || this.#findDep(host, devDependencies, 'dev')
       || this.#findTransientDep(host, request?.via);
 
-    this.#dependencies.set(host.uri, dep ?? false);
+    if (!request?.via || request?.via === this) {
+      this.#dependencies.set(host.uri, dep ?? false);
+    }
 
     return dep;
   }

--- a/src/impl/sub-package.resolution.ts
+++ b/src/impl/sub-package.resolution.ts
@@ -1,7 +1,6 @@
 import { ImportResolution } from '../resolution/import-resolution.js';
 import { Import } from '../resolution/import.js';
 import { PackageResolution } from '../resolution/package-resolution.js';
-import { recognizeImport } from '../resolution/recognize-import.js';
 import { SubPackageResolution } from '../resolution/sub-package-resolution.js';
 import { ImportResolver } from './import-resolver.js';
 import { Import$Resolution } from './import.resolution.js';
@@ -24,7 +23,7 @@ export abstract class SubPackage$Resolution<TImport extends Import.SubPackage>
   abstract get subpath(): '' | `/${string}` | `#${string}`;
 
   override async resolveImport(spec: Import | string): Promise<ImportResolution> {
-    spec = recognizeImport(spec);
+    spec = this.#resolver.recognizeImport(spec);
 
     switch (spec.kind) {
       case 'path':

--- a/src/impl/uri.resolution.ts
+++ b/src/impl/uri.resolution.ts
@@ -1,6 +1,5 @@
 import { ImportResolution } from '../resolution/import-resolution.js';
 import { Import } from '../resolution/import.js';
-import { recognizeImport } from '../resolution/recognize-import.js';
 import { ImportResolver } from './import-resolver.js';
 import { Import$Resolution } from './import.resolution.js';
 import { uriToImport } from './uri-to-import.js';
@@ -15,7 +14,7 @@ export class URI$Resolution extends Import$Resolution<Import.URI> {
   }
 
   override async resolveImport(spec: Import | string): Promise<ImportResolution> {
-    spec = recognizeImport(spec);
+    spec = this.#resolver.recognizeImport(spec);
 
     switch (spec.kind) {
       case 'uri':

--- a/src/package/package-info.spec.ts
+++ b/src/package/package-info.spec.ts
@@ -21,14 +21,6 @@ describe('PackageInfo', () => {
     });
   });
 
-  describe('loadSync', () => {
-    it('loads package info synchronously', () => {
-      const info = PackageInfo.loadSync();
-
-      expect(info.packageJson.name).toBe('@run-z/npk');
-    });
-  });
-
   describe('name', () => {
     it('defaults to -', () => {
       expect(new PackageInfo({}).name).toBe('-');

--- a/src/package/package-info.ts
+++ b/src/package/package-info.ts
@@ -1,5 +1,3 @@
-import fs from 'node:fs';
-import fsPromises from 'node:fs/promises';
 import { PackageEntryPoint } from './package-entry-point.js';
 import { PackageEntryTargets } from './package-entry-targets.js';
 import { PackageJson, PackagePath } from './package.json.js';
@@ -28,20 +26,9 @@ export class PackageInfo {
    * @returns Promise resolved to the loaded package info.
    */
   static async load(path = 'package.json'): Promise<PackageInfo> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return new PackageInfo(JSON.parse(await fsPromises.readFile(path, 'utf-8')));
-  }
+    const { default: fs } = await import('node:fs/promises');
 
-  /**
-   * Synchronously loads package info from `package,json` file at the given `path`.
-   *
-   * @param path - Path to `package.json` file. `package.json` by default.
-   *
-   * @returns Loaded package info.
-   */
-  static loadSync(path = 'package.json'): PackageInfo {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return new PackageInfo(JSON.parse(fs.readFileSync(path, 'utf-8')));
+    return new PackageInfo(JSON.parse(await fs.readFile(path, 'utf-8')) as PackageJson);
   }
 
   readonly #packageJson: PackageJson.Valid;

--- a/src/resolution/import-resolution.spec.ts
+++ b/src/resolution/import-resolution.spec.ts
@@ -22,6 +22,13 @@ describe('ImportResolution', () => {
       resolution = await root.resolveImport('http://localhost/pkg/test?ver=2.0.0');
     });
 
+    describe('fs', () => {
+      it('is set to package FS', () => {
+        expect(root.fs).toBe(fs);
+        expect(resolution.fs).toBe(fs);
+      });
+    });
+
     describe('resolutionBaseURI', () => {
       it('the same as URI', () => {
         expect(resolution.resolutionBaseURI).toBe(resolution.uri);

--- a/src/resolution/import-resolution.spec.ts
+++ b/src/resolution/import-resolution.spec.ts
@@ -3,6 +3,7 @@ import { resolveRootPackage } from '../fs/resolve-root-package.js';
 import { VirtualPackageFS } from '../fs/virtual-package-fs.js';
 import { ImportResolution } from './import-resolution.js';
 import { PackageResolution } from './package-resolution.js';
+import { recognizeImport } from './recognize-import.js';
 
 describe('ImportResolution', () => {
   let fs: VirtualPackageFS;
@@ -52,7 +53,9 @@ describe('ImportResolution', () => {
 
     describe('resolveImport', () => {
       it('resolves URI', async () => {
-        const uriResolution = await resolution.resolveImport('http://localhost/pkg/test?ver=3.0.0');
+        const uriResolution = await resolution.resolveImport(
+          recognizeImport('http://localhost/pkg/test?ver=3.0.0'),
+        );
 
         expect(uriResolution.importSpec).toEqual({
           kind: 'uri',

--- a/src/resolution/import-resolution.ts
+++ b/src/resolution/import-resolution.ts
@@ -1,3 +1,4 @@
+import { PackageFS } from '../fs/package-fs.js';
 import { ImportDependency } from './import-dependency.js';
 import { Import } from './import.js';
 import { PackageResolution } from './package-resolution.js';
@@ -11,6 +12,11 @@ import { SubPackageResolution } from './sub-package-resolution.js';
  * @typeParam TImport - Type of import specifier.
  */
 export interface ImportResolution<out TImport extends Import = Import> {
+  /**
+   * Package file system.
+   */
+  get fs(): PackageFS;
+
   /**
    * Root module resolution.
    *

--- a/src/resolution/import-resolution.ts
+++ b/src/resolution/import-resolution.ts
@@ -55,10 +55,14 @@ export interface ImportResolution<out TImport extends Import = Import> {
    * Resolves direct dependency of the module on another one.
    *
    * @param on - The package to resolve dependency on.
+   * @param request - Optional dependency resolution request.
    *
    * @returns Either dependency descriptor, or `null` if the module does not depend on another one.
    */
-  resolveDependency(on: ImportResolution): ImportDependency | null;
+  resolveDependency(
+    on: ImportResolution,
+    request?: ImportDependencyRequest,
+  ): ImportDependency | null;
 
   /**
    * Represents this module resolution as package resolution, if possible.
@@ -73,4 +77,17 @@ export interface ImportResolution<out TImport extends Import = Import> {
    * @returns `this` instance for sub-package or package resolution, or `undefined` otherwise.
    */
   asSubPackage(): SubPackageResolution | undefined;
+}
+
+/**
+ * {@link ImportResolution#resolveDependency Dependency resolution} request.
+ */
+export interface ImportDependencyRequest {
+  /**
+   * Intermediate module resolution for transitive dependency check.
+   *
+   * If target dependency is not found among direct dependencies, it can be search as a dependency of intermediate
+   * one. Then, the result would be base on how this module resolution depends on intermediate one.
+   */
+  readonly via?: ImportResolution | undefined;
 }

--- a/src/resolution/package-resolution.spec.ts
+++ b/src/resolution/package-resolution.spec.ts
@@ -268,14 +268,20 @@ describe('PackageResolution', () => {
       });
     });
     it('resolves transient runtime dependency', async () => {
-      fs.addRoot({ name: 'root', version: '1.0.0', dependencies: { dep: 'workspace:^1.0.0' } });
+      fs.addRoot({ name: 'root', version: '1.0.0', dependencies: { via: '^1.0.0' } });
+      fs.addPackage({
+        name: 'via',
+        version: '1.0.0',
+        dependencies: { dep: '^1.0.0' },
+      });
       fs.addPackage({ name: 'dep', version: '1.0.0' });
 
       root = await resolveRootPackage(fs);
 
-      const dep = (await root.resolveImport('dep')).asPackage()!;
+      const via = (await root.resolveImport('via/some')).asSubPackage()!;
+      const dep = (await via.resolveImport('dep/other')).asSubPackage()!;
 
-      expect(root.resolveDependency(dep)).toEqual({
+      expect(root.resolveDependency(dep, { via })).toEqual({
         kind: 'runtime',
         on: dep,
       });

--- a/src/resolution/package-resolution.spec.ts
+++ b/src/resolution/package-resolution.spec.ts
@@ -267,6 +267,19 @@ describe('PackageResolution', () => {
         on: dep,
       });
     });
+    it('resolves transient runtime dependency', async () => {
+      fs.addRoot({ name: 'root', version: '1.0.0', dependencies: { dep: 'workspace:^1.0.0' } });
+      fs.addPackage({ name: 'dep', version: '1.0.0' });
+
+      root = await resolveRootPackage(fs);
+
+      const dep = (await root.resolveImport('dep')).asPackage()!;
+
+      expect(root.resolveDependency(dep)).toEqual({
+        kind: 'runtime',
+        on: dep,
+      });
+    });
     it('resolves dev dependency', async () => {
       fs.addRoot({
         name: 'root',
@@ -280,6 +293,29 @@ describe('PackageResolution', () => {
       const dep = (await root.resolveImport('dep')).asPackage()!;
 
       expect(root.resolveDependency(dep)).toEqual({
+        kind: 'dev',
+        on: dep,
+      });
+    });
+    it('resolves transient dev dependency', async () => {
+      fs.addRoot({
+        name: 'root',
+        version: '1.0.0',
+        devDependencies: { via: '^1.0.0' },
+      });
+      fs.addPackage({
+        name: 'via',
+        version: '1.0.0',
+        dependencies: { dep: '^1.0.0' },
+      });
+      fs.addPackage({ name: 'dep', version: '1.0.0' });
+
+      root = await resolveRootPackage(fs);
+
+      const via = (await root.resolveImport('via')).asPackage()!;
+      const dep = (await via.resolveImport('dep')).asPackage()!;
+
+      expect(root.resolveDependency(dep, { via })).toEqual({
         kind: 'dev',
         on: dep,
       });
@@ -298,6 +334,26 @@ describe('PackageResolution', () => {
       const dep = (await root.resolveImport('dep')).asPackage()!;
 
       expect(root.resolveDependency(dep)).toEqual({
+        kind: 'peer',
+        on: dep,
+      });
+    });
+    it('resolves transient peer dependency', async () => {
+      fs.addRoot({
+        name: 'root',
+        version: '1.0.0',
+        peerDependencies: { via: '1.0.0' },
+        devDependencies: { via: '1.0.0' },
+      });
+      fs.addPackage({ name: 'via', version: '1.0.0', devDependencies: { dep: '^1.0.0' } });
+      fs.addPackage({ name: 'dep', version: '1.0.0' });
+
+      root = await resolveRootPackage(fs);
+
+      const via = (await root.resolveImport('via')).asPackage()!;
+      const dep = (await via.resolveImport('dep')).asPackage()!;
+
+      expect(root.resolveDependency(dep, { via })).toEqual({
         kind: 'peer',
         on: dep,
       });
@@ -359,6 +415,30 @@ describe('PackageResolution', () => {
       const dep = await root.resolveImport('dep');
 
       expect(root.resolveDependency(dep)).toBeNull();
+    });
+    it('does not resolve missing transient dependency', async () => {
+      fs.addRoot({ name: 'root', version: '1.0.0', dependencies: { via: '^1.0.0' } });
+      fs.addPackage({ name: 'via', version: '1.0.0' });
+      fs.addPackage({ name: 'dep', version: '2.0.0' });
+
+      root = await resolveRootPackage(fs);
+
+      const via = (await root.resolveImport('via')).asPackage()!;
+      const dep = (await root.resolveImport('package:dep/2.0.0')).asPackage()!;
+
+      expect(root.resolveDependency(dep, { via })).toBeNull();
+    });
+    it('does not resolve via missing interim dependency', async () => {
+      fs.addRoot({ name: 'root', version: '1.0.0' });
+      fs.addPackage({ name: 'via', version: '1.0.0', dependencies: { dep: '^2.0.0' } });
+      fs.addPackage({ name: 'dep', version: '2.0.0' });
+
+      root = await resolveRootPackage(fs);
+
+      const via = (await root.resolveImport('package:via/1.0.0')).asPackage()!;
+      const dep = (await root.resolveImport('package:dep/2.0.0')).asPackage()!;
+
+      expect(root.resolveDependency(dep, { via })).toBeNull();
     });
   });
 });

--- a/src/resolution/recognize-import.spec.ts
+++ b/src/resolution/recognize-import.spec.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from '@jest/globals';
-import { win32 } from 'node:path/win32';
 import { Import } from './import.js';
 import { recognizeImport } from './recognize-import.js';
 
@@ -8,54 +7,6 @@ describe('recognizeImport', () => {
     const spec: Import = { kind: 'unknown', spec: '_path/to/file' };
 
     expect(recognizeImport(spec)).toBe(spec);
-  });
-
-  describe('node imports', () => {
-    it('recognized with "node:" prefix', () => {
-      expect(recognizeImport('node:fs')).toEqual({
-        kind: 'implied',
-        spec: 'node:fs',
-        from: 'node',
-      });
-    });
-    it('recognizes built-in module name', () => {
-      expect(recognizeImport('fs')).toEqual({
-        kind: 'implied',
-        spec: 'fs',
-        from: 'node',
-      });
-      expect(recognizeImport('path')).toEqual({
-        kind: 'implied',
-        spec: 'path',
-        from: 'node',
-      });
-    });
-    it('recognizes sub-export of built-in module', () => {
-      expect(recognizeImport('fs/promises')).toEqual({
-        kind: 'implied',
-        spec: 'fs/promises',
-        from: 'node',
-      });
-      expect(recognizeImport('stream/web')).toEqual({
-        kind: 'implied',
-        spec: 'stream/web',
-        from: 'node',
-      });
-    });
-    it('does not recognize wrong node built-in with "node:" prefix', () => {
-      expect(recognizeImport('node:wrong-module')).toEqual({
-        kind: 'uri',
-        spec: 'node:wrong-module',
-        scheme: 'node',
-        path: 'wrong-module',
-      });
-      expect(recognizeImport('node:fs/wrong-sub-module')).toEqual({
-        kind: 'uri',
-        spec: 'node:fs/wrong-sub-module',
-        scheme: 'node',
-        path: 'fs/wrong-sub-module',
-      });
-    });
   });
 
   describe('package imports', () => {
@@ -142,103 +93,26 @@ describe('recognizeImport', () => {
         uri: '..',
       });
     });
-    it('recognizes absolute unix path', () => {
+    it('recognizes absolute path', () => {
       const spec = '/test path';
 
       expect(recognizeImport(spec)).toEqual({
         kind: 'path',
         spec,
         isRelative: false,
-        path: '/test%20path',
-        uri: '/test%20path',
+        path: '/test path',
+        uri: '/test path',
       });
     });
-    it('recognizes windows path with drive letter', () => {
-      const spec = 'c:\\dir\\test path';
-
-      expect(recognizeImport(spec)).toEqual({
-        kind: 'path',
-        spec,
-        isRelative: false,
-        path: `/c:/dir/test%20path`,
-        uri: `file:///c:/dir/test%20path`,
-      });
-    });
-    it('recognizes absolute windows path with drive letter', () => {
-      const spec = '\\c:\\dir\\test path';
-
-      expect(recognizeImport(spec)).toEqual({
-        kind: 'path',
-        spec,
-        isRelative: false,
-        path: `/c:/dir/test%20path`,
-        uri: `file:///c:/dir/test%20path`,
-      });
-    });
-    it('recognizes absolute windows path', () => {
-      const spec = '\\\\server\\test path';
-
-      expect(recognizeImport(spec)).toEqual({
-        kind: 'path',
-        spec,
-        isRelative: false,
-        path: `//%3F/UNC/server/test%20path/`,
-        uri: `file:////%3F/UNC/server/test%20path/`,
-      });
-    });
-    it('recognizes UNC windows path', () => {
-      const spec = win32.toNamespacedPath('\\\\server\\test path');
-
-      expect(recognizeImport(spec)).toEqual({
-        kind: 'path',
-        spec,
-        isRelative: false,
-        path: `//%3F/UNC/server/test%20path/`,
-        uri: `file:////%3F/UNC/server/test%20path/`,
-      });
-    });
-    it('recognizes relative unix path', () => {
+    it('recognizes relative path', () => {
       const spec = './test path?q=a';
 
       expect(recognizeImport(spec)).toEqual({
         kind: 'path',
         spec,
         isRelative: true,
-        path: './test%20path?q=a',
-        uri: './test%20path?q=a',
-      });
-    });
-    it('recognizes relative windows path', () => {
-      const spec = '.\\test path';
-
-      expect(recognizeImport(spec)).toEqual({
-        kind: 'path',
-        spec,
-        isRelative: true,
-        path: './test%20path',
-        uri: './test%20path',
-      });
-    });
-    it('recognizes unix path relative to parent directory', () => {
-      const spec = '../test path#q=a';
-
-      expect(recognizeImport(spec)).toEqual({
-        kind: 'path',
-        spec,
-        isRelative: true,
-        path: '../test%20path#q=a',
-        uri: '../test%20path#q=a',
-      });
-    });
-    it('recognizes windows path relative to parent directory', () => {
-      const spec = '..\\test path';
-
-      expect(recognizeImport(spec)).toEqual({
-        kind: 'path',
-        spec,
-        isRelative: true,
-        path: '../test%20path',
-        uri: '../test%20path',
+        path: './test path?q=a',
+        uri: './test path?q=a',
       });
     });
   });


### PR DESCRIPTION
- Create `NodePackageFS` asynchronously
- File system-specific import recognition
- Unify `peerDependencies` access
- Transitive dependency resolution
- Expose package FS
- Do not cache transient dependencies
- Fix dependency targets
